### PR TITLE
chore: add permissions to cd workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,6 +15,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: 'read'
+      id-token: write
+
     env:
       GCP_PROJECT_ID: github-app-notify-twitter
       GCP_CLOUDRUN_SERVICE_REGION: europe-west1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: 'read'
+      contents: read
       id-token: write
 
     env:


### PR DESCRIPTION
Added permissions to the CD workflow that should solve the following issue:
```
google-github-actions/auth failed with: gitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or $ACTIONS_ID_TOKEN_REQUEST_URL into this job.
```

Closes #12 