### PR TITLE
fastify listen deprecated signature

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const server = buildServer(config)
 const start = async () => {
   try {
     const port = process.env.PORT || 8080
-    await server.listen(port, '0.0.0.0')
+    await server.listen({ port, host: '0.0.0.0' })
   } catch (err) {
     server.log.error(err)
     process.exit(1)


### PR DESCRIPTION
changed fastify listen signature to optsObject since the variadic is is no longer supported
resolves: https://github.com/nearform/github-app-notify-twitter/issues/133