### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "test": "jest",
-    "prepare": "npx husky install",
+    "prepare": "npx husky",
     "start": "node index.js"
   },
   "repository": {


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)